### PR TITLE
修改xcode升级为9.1版本不能运行的错误

### DIFF
--- a/XCTestWD-master/XCTestWD/XCTestWDUITests/server/models/XCTestWDSession.swift
+++ b/XCTestWD-master/XCTestWD/XCTestWDUITests/server/models/XCTestWDSession.swift
@@ -187,7 +187,11 @@ extension HttpRequest {
     
     var jsonBody:JSON {
         get {
-            return JSON(data: NSData(bytes: &self.body, length: self.body.count) as Data)
+			do{
+				let data = try JSON(data: NSData(bytes: &self.body, length: self.body.count) as Data)
+				return data
+			}catch{
+				return "data error"
         }
     }
 }


### PR DESCRIPTION
修改XCTestWDSession.swift 文件，增加try catch